### PR TITLE
✨ Base on MySQL 5.7 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM mariadb:latest
+FROM mysql:5.7
 
 # backups to Google Storage
 RUN    apt-get update \
-    && apt-get install -y wget unzip python cron \
+    && apt-get install -y wget unzip python \
     && rm -rf /var/lib/apt/lists/*
 
 # download google cloud-sdk


### PR DESCRIPTION
Because we backup MySQL and not MariaDB, then switch to MySQL upstream image remove cron, we do not use cron anymore